### PR TITLE
AVRDude: Redefine HAVE_LINUX_GPIO

### DIFF
--- a/avrdude/pindefs.h
+++ b/avrdude/pindefs.h
@@ -59,7 +59,7 @@ enum {
 #define PIN_MIN     0   /* smallest allowed pin number */
 #define PIN_MAX     31  /* largest allowed pin number */
 
-#ifdef HAVE_LINUX_GPIO
+#ifdef HAVE_LINUXGPIO
 /* Embedded systems might have a lot more gpio than only 0-31 */
 #undef PIN_MAX
 #define PIN_MAX     255 /* largest allowed pin number */


### PR DESCRIPTION
Fix a misnamed defined variable, "HAVE_LINUX_GPIO", as it should be
"HAVE_LINUXGPIO" (as it is in the rest of the source).

Signed-off-by: Sam Voss <samuel.voss@rockwellcollins.com>