### PR TITLE
If a file open in linuxspi_gpio_op_wr fails, retry after a delay

### DIFF
--- a/avrdude/linuxspi.c
+++ b/avrdude/linuxspi.c
@@ -166,6 +166,14 @@ static int linuxspi_gpio_op_wr(PROGRAMMER* pgm, LINUXSPI_GPIO_OP op, int gpio, c
     
     FILE* f = fopen(fn, "w");
     
+    int fopen_retries = 0;
+    while (!f && fopen_retries < 100)
+    {
+        usleep(20000);
+        f = fopen(fn, "w");
+        fopen_retries++;
+    }
+
     if (!f)
     {
         fprintf(stderr, "%s: linuxspi_gpio_op_wr(): Unable to open file %s", progname, fn);


### PR DESCRIPTION
Setting the reset pin direction immediately after export doesn't allow enough time for the udev rule to give access rights to the gpio user group. This causes avrdude commands run as non-root to fail:
```
avrdude: linuxspi_gpio_op_wr(): Unable to open file /sys/class/gpio/gpio25/direction
```

This code is based on the patch in https://github.com/kcuzner/avrdude/issues/10 but it doesn't impose a fixed delay of 2 seconds. On my RPi 3 B+, I find a delay of 50 ms is all that's needed.

Your patch is currently being [beta tested](https://github.com/facchinm/avrdude/commits/b5f8cd7f7235e441dccd7541e5c8c66d0096cafa/avrdude/linuxspi.h) for inclusion in the [next release of the Arduino IDE/Arduino AVR Boards](https://github.com/arduino/toolchain-avr/pull/47) but this issue makes the linuxspi programmer not terribly useful to Arduino IDE users. So, even if things aren't moving forward quickly for merging your patch in mainline AVRDUDE, it would still be very helpful to get this issue resolved and the patch updated.

I welcome any suggestions for improvement of this code.

Fixes https://github.com/kcuzner/avrdude/issues/10
CC: @thinkingcow